### PR TITLE
76x76

### DIFF
--- a/lib/settings.js
+++ b/lib/settings.js
@@ -291,7 +291,7 @@ exports.options = {
             infix: false,
             suffix: '.png',
             sizes: [
-                60
+                76
             ]
         },
         ios_icon76_2x:{


### PR DESCRIPTION
Missing required icon file. The bundle does not contain an app icon for iPad of exactly '76x76' pixels, in .png format for iOS versions >= 7.0.

@codenamezjames