### PR TITLE
Corrected some sizes for the iOS app icons and added a couple more.  …

### DIFF
--- a/lib/settings.js
+++ b/lib/settings.js
@@ -119,20 +119,12 @@ exports.options = {
       suffix: '.png',
       sizes: [192]
     },
-    ios_adhoc_itunesadhoc: {
+    ios_adhoc_app_store_ios: {
       // iOS 7+
       folder: 'cordova/ios',
-      prefix: 'iTunesArtwork',
+      prefix: 'icon-1024',
       infix: false,
-      suffix: '',
-      sizes: [512]
-    },
-    ios_adhoc_itunesadhoc_2x: {
-      // iOS 7+
-      folder: 'cordova/ios',
-      prefix: 'iTunesArtwork@2x',
-      infix: false,
-      suffix: '',
+      suffix: '.png',
       sizes: [1024]
     },
     ios_watch_appicon40: {
@@ -229,7 +221,7 @@ exports.options = {
       prefix: 'icon-76',
       infix: false,
       suffix: '.png',
-      sizes: [60]
+      sizes: [76]
     },
     ios_icon76_2x: {
       // iPad
@@ -238,6 +230,14 @@ exports.options = {
       infix: false,
       suffix: '.png',
       sizes: [152]
+    },
+    ios_icon20: {
+      // iPad notification icon
+      folder: 'cordova/ios',
+      prefix: 'icon-20',
+      infix: false,
+      suffix: '.png',
+      sizes: [20]
     },
     ios_icon40: {
       // Spotlight Icon
@@ -285,7 +285,7 @@ exports.options = {
       prefix: 'icon-72@2x',
       infix: false,
       suffix: '.png',
-      sizes: [57]
+      sizes: [144]
     },
     ios_icon_small: {
       // iPhone Spotlight and Settings
@@ -303,6 +303,14 @@ exports.options = {
       suffix: '.png',
       sizes: [58]
     },
+    ios_icon_small_3x: {
+      // iPhone Spotlight and Settings
+      folder: 'cordova/ios',
+      prefix: 'icon-small@3x',
+      infix: false,
+      suffix: '.png',
+      sizes: [87]
+    },
     ios_icon_50: {
       // iPad Spotlight & Settings
       folder: 'cordova/ios',
@@ -317,7 +325,7 @@ exports.options = {
       prefix: 'icon-50@2x',
       infix: false,
       suffix: '.png',
-      sizes: [57]
+      sizes: [100]
     },
     ios_icon_167: {
       // iPad Pro


### PR DESCRIPTION
…Also replaced "iTunesArtwork@2x" with "icon-1024.png" for consistency in naming, and removed "iTunesArtwork" (since the 512 pixel image doesn't appear to be used in Xcode 10.1)